### PR TITLE
feat(kafka): add switchable curl linkage to unlock OIDC auth (#21605)

### DIFF
--- a/.github/workflows/dynamic_curl.yml
+++ b/.github/workflows/dynamic_curl.yml
@@ -2,9 +2,6 @@ name: Dynamic curl build (x86_64-unknown-linux-gnu)
 
 on:
   workflow_dispatch:
-  # or run when a PR is opened/updated that targets `main`
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/dynamic_curl.yml
+++ b/.github/workflows/dynamic_curl.yml
@@ -2,6 +2,9 @@ name: Dynamic curl build (x86_64-unknown-linux-gnu)
 
 on:
   workflow_dispatch:
+  # or run when a PR is opened/updated that targets `main`
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/dynamic_curl.yml
+++ b/.github/workflows/dynamic_curl.yml
@@ -1,0 +1,29 @@
+name: Dynamic curl build (x86_64-unknown-linux-gnu)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Vector (dynamic curl)
+    runs-on: ubuntu-24.04
+    env:
+      CARGO_INCREMENTAL: 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross
+        run: |
+          rustup target add x86_64-unknown-linux-gnu
+          cargo install cross --version 0.2.4 --force --locked
+
+      - name: Build with dynamic curl
+        run: |
+          cross build --release --target x86_64-unknown-linux-gnu \
+            --no-default-features \
+            --features target-x86_64-unknown-linux-gnu,rdkafka-curl-dynamic
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vector-dynamic-curl-x86_64-unknown-linux-gnu
+          path: ./target/x86_64-unknown-linux-gnu/release/vector

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ pulsar = { version = "6.3.1", default-features = false, features = ["tokio-runti
 quick-junit = { version = "0.5.1" }
 rand.workspace = true
 rand_distr.workspace = true
-rdkafka = { version = "0.37.0", default-features = false, features = ["curl-static", "tokio", "libz", "ssl", "zstd"], optional = true }
+rdkafka = { version = "0.37.0", default-features = false, features = ["tokio", "libz", "ssl", "zstd"], optional = true }
 redis = { version = "0.32.4", default-features = false, features = ["connection-manager", "sentinel", "tokio-comp", "tokio-native-tls-comp"], optional = true }
 regex = { version = "1.11.1", default-features = false, features = ["std", "perf"] }
 roaring = { version = "0.11.2", default-features = false, features = ["std"], optional = true }
@@ -506,6 +506,10 @@ target-powerpc-unknown-linux-gnu = ["api", "api-client", "enrichment-tables", "r
 # Enables features that work only on systems providing `cfg(unix)`
 unix = ["tikv-jemallocator", "allocation-tracing"]
 allocation-tracing = []
+
+# rdkafka curl linking selection
+rdkafka-curl-static = ["rdkafka/curl-static"]
+rdkafka-curl-dynamic = ["rdkafka/curl"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.
@@ -640,7 +644,7 @@ sources-internal_logs = []
 sources-internal_metrics = []
 sources-static_metrics = []
 sources-journald = []
-sources-kafka = ["dep:rdkafka"]
+sources-kafka = ["dep:rdkafka", "rdkafka-curl-static"]
 sources-kubernetes_logs = ["vector-lib/file-source", "kubernetes", "transforms-reduce"]
 sources-logstash = ["sources-utils-net-tcp", "tokio-util/net"]
 sources-mongodb_metrics = ["dep:mongodb"]
@@ -824,7 +828,7 @@ sinks-honeycomb = []
 sinks-http = []
 sinks-humio = ["sinks-splunk_hec", "transforms-metric_to_log"]
 sinks-influxdb = []
-sinks-kafka = ["dep:rdkafka"]
+sinks-kafka = ["dep:rdkafka", "rdkafka-curl-static"]
 sinks-keep = []
 sinks-mezmo = []
 sinks-loki = ["loki-logproto"]


### PR DESCRIPTION
WHY
Issue #21605 highlights that Kafka source/sink builds lack OAUTHBEARER / OIDC support because librdkafka requires dynamic libcurl.

Vector currently compiles rdkafka with curl-static, so OAuth options are silently disabled at build-time.

This patch introduces an opt-in dynamic curl path while preserving today’s static-curl default, allowing users (and CI) to produce binaries that fully support OIDC authentication.

WHAT
Cargo.toml
* Removed curl-static from the core rdkafka dependency.
* Added additive feature flags
* rdkafka-curl-static → rdkafka/curl-static (default)
* rdkafka-curl-dynamic → rdkafka/curl
* Kept existing behaviour by including rdkafka-curl-static in sources-kafka and sinks-kafka. .github/workflows/dynamic_curl.yml
* New workflow that cross-builds x86_64-unknown-linux-gnu with `--features target-x86_64-unknown-linux-gnu,rdkafka-curl-dynamic` and uploads the artefact `vector-dynamic-curl-x86_64-unknown-linux-gnu`.

HOW TO USE
Static (unchanged):
```
cargo build --release          # same binary as before
```
Dynamic curl / OIDC-ready:
```
cargo build --release --no-default-features \
  --features target-x86_64-unknown-linux-gnu,rdkafka-curl-dynamic
```
or download the artefact from the new “Dynamic curl build” GitHub Action.

## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [ ] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue number>
- Related: #<issue number>
- Related: #<PR number>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `cargo fmt --all`
    - `cargo clippy --workspace --all-targets -- -D warnings`
    - `cargo nextest run --workspace` (alternatively, you can run `cargo test --all`)
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `cargo vdev build licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
